### PR TITLE
get language base path based on tenancy

### DIFF
--- a/src/ChainedTranslationManager.php
+++ b/src/ChainedTranslationManager.php
@@ -230,8 +230,16 @@ class ChainedTranslationManager
 
     private function getGroupPath(string $locale, string $group, string $languagePath=null): string
     {
+        $tenant = \Filament\Facades\Filament::getTenant();
+
+        if ($tenant) {
+            $languagePath = base_path("lang-custom/labels/{$tenant->domain}");
+        } else {
+            $languagePath = ($languagePath ?? $this->path);
+        }
+
         if ($group === $this->getJsonGroupName()) {
-            return ($languagePath ?? $this->path).DIRECTORY_SEPARATOR.$locale.'.json';
+            return $languagePath . DIRECTORY_SEPARATOR . $locale . '.json';
         }
 
         $basePath = $this->getGroupBasePath($locale, $group, $languagePath);
@@ -239,7 +247,7 @@ class ChainedTranslationManager
         $this->pullNamespaceFromGroup($group);
         $this->pullSubfoldersFromGroup($group);
 
-        return $basePath.DIRECTORY_SEPARATOR.$group.'.php';
+        return $basePath . DIRECTORY_SEPARATOR . $group . '.php';
     }
 
     private function getGroupBasePath(string $locale, string $group, string $languagePath=null): string


### PR DESCRIPTION
This pull request modifies the `saveGroupTranslations` functionality in `src/ChainedTranslationManager.php` to introduce tenant-specific language paths. The most important change ensures that translations are saved in a tenant-specific directory if a tenant is detected, otherwise falling back to the default language path.

### Tenant-specific language path handling:
* [`src/ChainedTranslationManager.php`](diffhunk://#diff-529ddfe16f0c861290708b052cc2e6fa17828e16fec92949e736fbf414cb21b0R233-R242): Added logic to determine the `languagePath` based on the current tenant's domain using `Filament::getTenant()`. If no tenant is detected, the default path is used. This change ensures tenant-specific translations are stored in a dedicated directory (`lang-custom/labels/{tenant->domain}`).